### PR TITLE
Mokkery Gradle Plugin

### DIFF
--- a/website/docs/Setup.mdx
+++ b/website/docs/Setup.mdx
@@ -59,9 +59,12 @@ pluginManagement {
     }
 }
 ```
+
+
 ### Convention plugins
 
 For those using convention plugins, make sure that the dependencies configuration includes the path to the required Maven repository, which can be added using `gradlePluginPortal()`.
+
 ```kotlin
 dependencyResolutionManagement {
     repositories {
@@ -73,6 +76,7 @@ dependencyResolutionManagement {
 ```
 
 Once the required Maven repository is connected, you will be able to successfully download the Mokkery plugin dependency.
+
 ```kotlin
 dependencies {
     implementation("dev.mokkery:mokkery-gradle:2.1.1")

--- a/website/docs/Setup.mdx
+++ b/website/docs/Setup.mdx
@@ -59,6 +59,29 @@ pluginManagement {
     }
 }
 ```
+
+For those using convention plugins, make sure that the dependencies configuration includes the path to the required Maven repository.
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        // required to download gradle plugin
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
+    }
+}
+```
+
+
+Once the required Maven repository is connected, you will be able to successfully download the Mokkery plugin dependency.
+```kotlin
+dependencies {
+    implementation("dev.mokkery:mokkery-gradle:2.1.1)
+}
+```
+
 ### Source sets
 
 By default, Mokkery is applied to all Kotlin source sets in the project that either contain the word 'Test' in their names or are named exactly 'test'.

--- a/website/docs/Setup.mdx
+++ b/website/docs/Setup.mdx
@@ -59,26 +59,23 @@ pluginManagement {
     }
 }
 ```
+### Convention plugins
 
-For those using convention plugins, make sure that the dependencies configuration includes the path to the required Maven repository.
-
+For those using convention plugins, make sure that the dependencies configuration includes the path to the required Maven repository, which can be added using `gradlePluginPortal()`.
 ```kotlin
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
         // required to download gradle plugin
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
+        gradlePluginPortal()
     }
 }
 ```
 
-
 Once the required Maven repository is connected, you will be able to successfully download the Mokkery plugin dependency.
 ```kotlin
 dependencies {
-    implementation("dev.mokkery:mokkery-gradle:2.1.1)
+    implementation("dev.mokkery:mokkery-gradle:2.1.1")
 }
 ```
 


### PR DESCRIPTION
For the Docosaurus website, added a description of what needs to be considered when working with Mokkery and Convention Plugins.

<img width="845" alt="image" src="https://github.com/lupuuss/Mokkery/assets/73034324/1c6fbfd4-5b76-4f65-a433-96b62cdeb332">
